### PR TITLE
Compiling on osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 $(PLATFORMS):
 	make -C dokidoki-support $@ \
 		NAME="../$(NAME)" \
-		EXTRA_CFLAGS="-DEXTRA_LOADERS=\"../extra_loaders.h\" $(EXTRA_CFLAGS)" \
+		EXTRA_CFLAGS="-DEXTRA_LOADERS='\"../extra_loaders.h\"' $(EXTRA_CFLAGS)" \
 		EXTRA_OBJECTS="../particles.o"
 
 clean:

--- a/compiling.txt
+++ b/compiling.txt
@@ -8,9 +8,9 @@ Linux:   make linux
 OS X:    make macosx
 Windows: make mingw
 
-Pax Britannica depends on lua 5.1 and glfw. On some systems you might need to
-tell the build process where to find these. On Ubuntu, for example, the
-liblua5.1-dev package installs lua as lua5.1, so you need to use
+Pax Britannica depends on lua 5.1, portaudio and glfw. On some systems you
+might need to tell the build process where to find these. On Ubuntu, for
+example, the liblua5.1-dev package installs lua as lua5.1, so you need to use
     make linux EXTRA_CFLAGS=-I/usr/include/lua5.1
 and additionally change -llua in dokidoki-support/Makefile to -llua5.1
 


### PR DESCRIPTION
I just got Pax Brittanica compiling on OSX Mountain Lion. To do this, I had to make a small modification in the escaping of a preprocessor variable. In addition I added the portaudio requirement in the compiling instructions.
